### PR TITLE
Dev

### DIFF
--- a/01-env_init.yml
+++ b/01-env_init.yml
@@ -11,8 +11,3 @@
     - setup:
   roles:
     - init
-  post_tasks:
-    - pause:
-        prompt: |
-          You should reboot the systems before next move if they are new.
-          Press ENTER to continue.

--- a/02-deploy_consul.yml
+++ b/02-deploy_consul.yml
@@ -18,7 +18,7 @@
       rescue:
         - service:
             name: consul
-            status: restarted
+            state: restarted
         - wait_for:
             port: 8600
             timeout: 30

--- a/02-deploy_consul.yml
+++ b/02-deploy_consul.yml
@@ -5,7 +5,7 @@
     - 30%
   vars_prompt:
     - name: "bootstrap"
-      prompt: "First time to deploy?(y/N)"
+      prompt: "Bootstrap a consul cluster?(y/N)"
       default: 'N'
       private: no
   roles:

--- a/03-deploy_elasticsearch.yml
+++ b/03-deploy_elasticsearch.yml
@@ -1,11 +1,9 @@
 - hosts: elasticsearch
   become: yes
-  serial:
-    - 1
-    - 10%
+  serial: 1
   roles:
-    - deploy.ElasticSearch
     - deploy.Consul
+    - deploy.ElasticSearch
     - deploy.Monit
   post_tasks:
     - block:

--- a/04-deploy_kibana.yml
+++ b/04-deploy_kibana.yml
@@ -4,8 +4,8 @@
     - 1
     - 30%
   roles:
-    - deploy.Kibana
     - deploy.Consul
+    - deploy.Kibana
     - deploy.Monit
   post_tasks:
     - block:

--- a/05-deploy_logstash.yml
+++ b/05-deploy_logstash.yml
@@ -4,8 +4,8 @@
     - 1
     - 10%
   roles:
-    - deploy.Logstash
     - deploy.Consul
+    - deploy.Logstash
     - deploy.Monit
   post_tasks:
     - block:

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -9,7 +9,8 @@ kibana_port: '5601'
 # Elasticsearch configure
 elastic_cluster_name: 'quanduan'
 elastic_log_path: '/var/log/elasticsearch'
-elastic_data_path: '/var/lib/elasticsearch'
+elastic_data_path:
+  - /var/lib/elasticsearch
 
 # LogStash configure
 logstash_data_path: '/var/lib/logstash'

--- a/roles/deploy.Consul/tasks/download.yml
+++ b/roles/deploy.Consul/tasks/download.yml
@@ -1,8 +1,9 @@
 - block:
-    - stat:
-        path: downloaded_files/consul_{{ consul_version }}_linux_amd64.zip
-      register: p
-      failed_when: p.stat.exists == false
+    - name: checking local consul command
+      shell: downloaded_files/consul version | head -n1 | awk '{ gsub("v","") ; print $2 }'
+      register: verChk
+      changed_when: false
+      failed_when: "consul_version > verChk.stdout"
       delegate_to: localhost
       become: no
       run_once: true

--- a/roles/deploy.Consul/tasks/install.yml
+++ b/roles/deploy.Consul/tasks/install.yml
@@ -4,6 +4,12 @@
         src: downloaded_files/consul
         dest: /usr/local/bin/consul
         mode: 0755
+    - name: starting consul service
+      service:
+        name: consul
+        state: started
+        enabled: true
+        daemon_reload: true
   rescue:
     - include_tasks: download.yml
     - include_tasks: install.yml

--- a/roles/deploy.Consul/templates/config.json.j2
+++ b/roles/deploy.Consul/templates/config.json.j2
@@ -1,16 +1,28 @@
 {
 {% if bootstrap == 'y' and inventory_hostname == groups['elasticMasterNode'][0] %}
   "bootstrap": true,
-{% endif %}
-{% if 'elasticMasterNode' in group_names %}
   "server": true,
-  "ui": true,
+{% endif %}
+{# ---------------- #}
+{% if bootstrap == 'N' and inventory_hostname == groups['elasticMasterNode'][0] %}
+"server": true,
+"start_join": [
+  {%- for item in groups['elasticMasterNode'] if item != ansible_nodename -%}
+    "{{ hostvars[item]['ansible_host'] | default(item) }}"{%- if loop.nextitem is defined -%},{%- endif -%}
+  {%- endfor -%}
+],
+{% endif %}
+{# ---------------- #}
+{% if 'elasticMasterNode' in group_names and inventory_hostname != groups['elasticMasterNode'][0] %}
+  "server": true,
   "start_join": [
     {%- for item in groups['elasticMasterNode'] if item != ansible_nodename -%}
       "{{ hostvars[item]['ansible_host'] | default(item) }}"{%- if loop.nextitem is defined -%},{%- endif -%}
     {%- endfor -%}
   ],
-{% else %}
+{% endif %}
+{# ---------------- #}
+{% if 'elasticMasterNode' not in group_names %}
   "server": false,
   "start_join": [
     {%- for item in groups['elasticMasterNode'] -%}
@@ -18,6 +30,7 @@
     {%- endfor -%}
   ],
 {% endif %}
+{# ---------------- #}
   "datacenter": "{{ consul_dc_name }}",
   "data_dir": "/var/consul",
   "encrypt": "{{ consul_key }}",

--- a/roles/deploy.Consul/templates/consul.service.j2
+++ b/roles/deploy.Consul/templates/consul.service.j2
@@ -10,6 +10,7 @@ Group=consul
 EnvironmentFile=-/etc/default/consul
 Restart=on-failure
 ExecStart=/usr/local/bin/consul agent -pid-file=/var/consul/consul.pid -config-dir=/etc/consul.d/
+ExecStop=/usr/local/bin/consul leave
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]

--- a/roles/deploy.Consul/templates/elasticsearch.json.j2
+++ b/roles/deploy.Consul/templates/elasticsearch.json.j2
@@ -9,7 +9,7 @@
       ],
       "checks": [
         {
-          "http": "http://{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}:{{ elastic_http_port }}",
+          "http": "http://localhost:{{ elastic_http_port }}",
           "interval": "10s",
           "timeout": "1s"
         }

--- a/roles/deploy.Consul/templates/kibana.json.j2
+++ b/roles/deploy.Consul/templates/kibana.json.j2
@@ -9,7 +9,7 @@
       ],
       "checks": [
         {
-          "http": "http://{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}:{{ kibana_port }}",
+          "http": "http://localhost:{{ kibana_port }}",
           "interval": "10s",
           "timeout": "1s"
         }

--- a/roles/deploy.Consul/templates/logstash.json.j2
+++ b/roles/deploy.Consul/templates/logstash.json.j2
@@ -9,7 +9,7 @@
       ],
       "checks": [
         {
-          "tcp": "{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}:{{ logstash_beats_port }}",
+          "tcp": "localhost:{{ logstash_beats_port }}",
           "interval": "10s",
           "timeout": "1s"
         }

--- a/roles/deploy.ElasticSearch/files/allocation.json
+++ b/roles/deploy.ElasticSearch/files/allocation.json
@@ -1,0 +1,14 @@
+PUT _template/active-logs
+{
+  "index_patterns": "filebeat-*",
+  "settings": {
+    "number_of_shards":   3,
+    "number_of_replicas": 1,
+    "routing.allocation.require.box_type": "hot",
+    "routing.allocation.total_shards_per_node": 2
+  },
+  "aliases": {
+    "active-logs":  {},
+    "search-logs": {}
+  }
+}

--- a/roles/deploy.ElasticSearch/files/curator_actions.yml
+++ b/roles/deploy.ElasticSearch/files/curator_actions.yml
@@ -1,0 +1,41 @@
+actions:
+  1:
+    action: allocation
+    description: "Apply shard allocation filtering rules to the specified indices"
+    options:
+      key: box_type
+      value: warm
+      allocation_type: require
+      wait_for_completion: true
+      timeout_override:
+      continue_if_exception: false
+      disable_action: false
+    filters:
+    - filtertype: pattern
+      kind: prefix
+      value: (logstash|filebeat|metricbeat|packetbeat)-
+    - filtertype: age
+      source: name
+      direction: older
+      timestring: '%Y.%m.%d'
+      unit: days
+      unit_count: 3
+  2:
+      action: forcemerge
+      description: "Perform a forceMerge on selected indices to 'max_num_segments' per shard"
+      options:
+        max_num_segments: 1
+        delay:
+        timeout_override: 21600
+        continue_if_exception: false
+        disable_action: false
+      filters:
+      - filtertype: pattern
+        kind: prefix
+        value: (logstash|filebeat|metricbeat|packetbeat)-
+      - filtertype: age
+        source: name
+        direction: older
+        timestring: '%Y.%m.%d'
+        unit: days
+        unit_count: 3

--- a/roles/deploy.ElasticSearch/tasks/Debian.yml
+++ b/roles/deploy.ElasticSearch/tasks/Debian.yml
@@ -6,6 +6,12 @@
     - name: 'installing elasticsearch-{{ elk_version }}.deb'
       apt:
         deb: '/tmp/elasticsearch-{{ elk_version }}.deb'
+    - name: starting elasticsearch service
+      service:
+        name: elasticsearch
+        state: started
+        enabled: yes
+        daemon_reload: yes
   rescue:
     - include_tasks: download.yml format=deb
     - include_tasks: '{{ ansible_os_family }}.yml'

--- a/roles/deploy.ElasticSearch/tasks/RedHat.yml
+++ b/roles/deploy.ElasticSearch/tasks/RedHat.yml
@@ -7,6 +7,12 @@
       yum:
         name: '/tmp/elasticsearch-{{ elk_version }}.rpm'
         state: present
+    - name: starting elasticsearch service
+      service:
+        name: elasticsearch
+        state: started
+        enabled: yes
+        daemon_reload: yes
   rescue:
     - include_tasks: download.yml format=rpm
     - include_tasks: '{{ ansible_os_family }}.yml'

--- a/roles/deploy.ElasticSearch/tasks/main.yml
+++ b/roles/deploy.ElasticSearch/tasks/main.yml
@@ -9,7 +9,7 @@
 - block:
     - name: checking ElasticSearch version
       uri:
-        url: 'http://{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}:{{ elastic_http_port }}'
+        url: 'http://localhost:{{ elastic_http_port }}'
         return_content: yes
       register: versionCheck
       changed_when: false

--- a/roles/deploy.ElasticSearch/tasks/post_upgrade.yml
+++ b/roles/deploy.ElasticSearch/tasks/post_upgrade.yml
@@ -1,6 +1,6 @@
 - name: checking if the node has been back to cluster or not.
   uri:
-    url: 'http://{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}:{{ elastic_http_port }}/_cat/nodes'
+    url: 'http://localhost:{{ elastic_http_port }}/_cat/nodes'
     return_content: yes
   register: nodesSt
   until: "(ansible_hostname in nodesSt.content) or (hostvars[inventory_hostname]['ansible_host'] in nodesSt.content)"
@@ -9,14 +9,14 @@
 
 - name: enable shard allocation.
   uri:
-    url: "http://{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}:{{ elastic_http_port }}/_cluster/settings"
+    url: "http://localhost:{{ elastic_http_port }}/_cluster/settings"
     method: PUT
     body: "{{ lookup('file','enable_shard.json') }}"
     body_format: json
 
 - name: checking if the cluster is green or not.
   uri:
-    url: 'http://{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}:{{ elastic_http_port }}/_cat/health'
+    url: 'http://localhost:{{ elastic_http_port }}/_cat/health'
     return_content: yes
   register: healthSt
   until: "'green' in healthSt.content"

--- a/roles/deploy.ElasticSearch/tasks/pre_upgrade.yml
+++ b/roles/deploy.ElasticSearch/tasks/pre_upgrade.yml
@@ -1,6 +1,6 @@
 - name: checking cluster health status
   uri:
-    url: http://{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}:{{ elastic_http_port }}/_cluster/health
+    url: http://localhost:{{ elastic_http_port }}/_cluster/health
     method: GET
     return_content: yes
     body_format: json
@@ -12,7 +12,7 @@
 
 - name: stopping shards
   uri:
-    url: "http://{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}:{{ elastic_http_port }}/_cluster/settings"
+    url: "http://localhost:{{ elastic_http_port }}/_cluster/settings"
     method: PUT
     body: "{{ lookup('file','disable_shard.json') }}"
     body_format: json
@@ -24,6 +24,6 @@
 
 - name: waiting for port down
   wait_for:
-    host: "{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}"
+    host: "localhost"
     port: '{{ elastic_http_port }}'
     state: stopped

--- a/roles/deploy.ElasticSearch/templates/elasticsearch.yml.j2
+++ b/roles/deploy.ElasticSearch/templates/elasticsearch.yml.j2
@@ -25,9 +25,9 @@ node.name: {{ inventory_hostname }}
 # Add custom attributes to the node:
 #
 {% if 'elasticHotNode ' in group_names %}
-node.box_type: hot
+node.attr.box_type: hot
 {% elif 'elasticWarmNode' in group_names %}
-node.box_type: warm
+node.attr.box_type: warm
 {% endif %}
 # Role of the node in cluster:
 #
@@ -39,7 +39,10 @@ search.remote.connect: {{ search_remote_connect }}
 #
 # Path to directory where to store the data (separate multiple locations by comma):
 #
-path.data: {{ elastic_data_path }}
+path.data:
+{% for path in elastic_data_path %}
+  - {{ path }}
+{% endfor %}
 #
 # Path to log files:
 #
@@ -63,8 +66,13 @@ bootstrap.memory_lock: true
 #
 # Set the bind address to a specific IP (IPv4 or IPv6):
 #
+{% if node_ingest is defined and node_ingest == true %}
 network.host: _site_
 network.bind_host: 0.0.0.0
+{% else %}
+transport.host: _site_
+transport.bind_host: 0.0.0.0
+{% endif %}
 #
 # Set a custom port for HTTP:
 #

--- a/roles/deploy.Monit/handlers/main.yml
+++ b/roles/deploy.Monit/handlers/main.yml
@@ -3,3 +3,4 @@
     name: monit
     state: restarted
     enabled: yes
+    daemon_reload: yes

--- a/roles/deploy.Monit/tasks/install.yml
+++ b/roles/deploy.Monit/tasks/install.yml
@@ -27,6 +27,7 @@
   copy:
     src: monit.service
     dest: /lib/systemd/system/monit.service
+  notify: Enable monit service
 
 - name: Create /etc/monit.d
   file:

--- a/roles/deploy.Monit/templates/check_services.j2
+++ b/roles/deploy.Monit/templates/check_services.j2
@@ -7,7 +7,6 @@ check host CONSUL with address 127.0.0.1
   start program = "/usr/sbin/service consul start"
   stop program = "/usr/sbin/service consul stop"
   if failed port 8600 for 2 cycles then restart
-  if 3 restarts within 10 cycles then stop
 
 {% if 'logstash' in group_names %}
 check host LOGSTASH with address 127.0.0.1


### PR DESCRIPTION
FIX:
1. If the consul servers are shutdown completely, it will a problem when they come back online. To fix that, a temporary way is re-run the deploy_consul.yml playbook with bootstrap set 'y'. I'll be fix it with monit later.
1. Fix some typos.
1. Only elasticsearch ingest nodes are expose port 9200, to avoid wrong output settings in beats agent.
1. Fix some deploy issues.

修复：
1. 极端情况下，当 consul servers 都被关闭后，启动系统会导致 consul 集群建立失败。通过修改 config.json 文件的配置来解决。但还不是最终解决方案，最终解决方案会使用 monit 来监控 consul 日志并触发集群初始化动作。
2. 一些书写错误。
3. ES 集群只允许 ingest 节点暴露 9200 端口，避免发送端使用了错误的输出源地址。
4. 优化解决了部分部署问题。
